### PR TITLE
Allow no content return code from iland api and update naming of vali…

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,8 @@ History
 * Housekeeping and refactoring
 * Better CI setup
 * Sphynx doc and readthedocs.org publishing.
+* Support 204 no content HTTP return code
+* Fix naming of _validate_token method
 
 0.2.0 (2016-2-09)
 ------------------

--- a/iland/api.py
+++ b/iland/api.py
@@ -88,7 +88,7 @@ class Api(object):
                 self._get_access_token()
         return self._token
 
-    def _validToken(self):
+    def _validate_token(self):
         if self._token is not None:
             return int(round(time.time() * 1000)) < self._token_expiration_time
         return False
@@ -123,7 +123,7 @@ class Api(object):
         # iland cloud API prefix have to be ignored because they are here to
         # prevent JSON Hijacking
         json_obj = json.loads(r.content[5:].decode('UTF8'))
-        if r.status_code not in [200, 201, 202]:
+        if r.status_code not in [200, 201, 202, 204]:
             raise ApiException(json_obj)
         return json_obj
 


### PR DESCRIPTION
…date token method.

@cfsnyder @anguenot  I think 204 is also valid and I think the validate token endpoint should be renamed like this.