### PR TITLE
Remove base_url, access_token_url, and verify_ssl from constructor

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 ------------------
 
 * Use a `requests.Session` object for all api calls
+* Remove `base_url`, `access_token_url`, and `verify_ssl` from Api constructor
 
 0.7.3 (2017-05-18)
 ------------------

--- a/iland/api.py
+++ b/iland/api.py
@@ -21,7 +21,7 @@ class Api(object):
     _username = None
     _password = None
     _base_url = BASE_URL
-    _access_token_url = ACCESS_URL
+    _access_token_url_ = ACCESS_URL
     _refresh_token_url = REFRESH_URL
     _proxies = None
 
@@ -31,35 +31,30 @@ class Api(object):
     _verify_ssl = True
     _session = None
 
-    def __init__(self, client_id, client_secret, username, password,
-                 base_url=None, access_token_url=None, verify_ssl=True):
+    def __init__(self, client_id, client_secret, username, password):
         """Instantiate a new iland.Api object.
 
         :param client_id: the client identifier
         :param client_secret: the client secret
         :param username: the iland cloud username
         :param password: the iland cloud password
-        :param base_url: [optional] base url to contact the iland cloud API
-        :param access_token_url: [optional] access token url to contact the \
-        iland cloud API
-        :param verify_ssl: [optional] whether or not to verify endpoints SSL
         :return: Api Object
         """
         self._client_id = client_id
         self._client_secret = client_secret
         self._username = username
         self._password = password
-        if base_url is not None:
-            self._base_url = base_url
-        else:
-            self._base_url = BASE_URL
-        if access_token_url is not None:
-            self._access_token_url = access_token_url
-            #: Refresh token URL. (`refresh` query param is here only for mock
-            # testing reason)
-            self._refresh_token_url = access_token_url + '?refresh=1'
-        self._verify_ssl = verify_ssl
         self._session = requests.Session()
+
+    @property
+    def _access_token_url(self):
+        return self._access_token_url_
+
+    @_access_token_url.setter
+    def _access_token_url(self, access_token_url):
+        if access_token_url is not None:
+            self._access_token_url_ = access_token_url
+            self._refresh_token_url = access_token_url + '?refresh=1'
 
     def _get_access_token(self):
 

--- a/tests/test_iland.py
+++ b/tests/test_iland.py
@@ -10,8 +10,7 @@ import requests_mock
 
 import iland
 
-BASE_URL = 'http://mock.com/ecs'
-ACCESS_URL = iland.ACCESS_URL
+BASE_URL = 'http://example.com/ecs'
 
 VALID_TOKEN_PAYLOAD = {'expires_in': 12,
                        'access_token': 'AZERTYUIOP',
@@ -30,9 +29,9 @@ class TestIland(unittest.TestCase):
         self.api = iland.Api(client_id='fake',
                              client_secret='fake',
                              username='fake',
-                             password='fake',
-                             base_url=BASE_URL,
-                             access_token_url=ACCESS_URL)
+                             password='fake')
+        self.api._base_url = BASE_URL
+        self.api._access_token_url = iland.ACCESS_URL
 
     def test_login_ok_200(self):
         with requests_mock.mock() as m:

--- a/tests/test_iland_int.py
+++ b/tests/test_iland_int.py
@@ -47,8 +47,8 @@ class TestIlandInt(unittest.TestCase):
         self._api = iland.Api(client_id=CLIENT_ID,
                               client_secret=CLIENT_SECRET,
                               username=USERNAME,
-                              password=PASSWORD,
-                              base_url=iland.constant.BASE_URL)
+                              password=PASSWORD)
+        self._api._base_url = iland.constant.BASE_URL
 
     def tearDown(self):
         pass
@@ -120,8 +120,9 @@ class TestIlandInt(unittest.TestCase):
         wrongCredsApi = iland.Api(client_id=CLIENT_ID,
                                   client_secret=CLIENT_SECRET,
                                   username='PYTHON_SDK_TEST',
-                                  password='XXXX',
-                                  base_url=iland.constant.BASE_URL)
+                                  password='XXXX')
+        wrongCredsApi._base_url = iland.constant.BASE_URL
+
         with self.assertRaises(UnauthorizedException):
             wrongCredsApi.login()
 


### PR DESCRIPTION
* Also changed test `BASE_URL` to point to example.com as designated per [RFC 2606](https://tools.ietf.org/html/rfc2606) as a reserved domain for [testing and examples](https://en.wikipedia.org/wiki/Example.com).