### PR TITLE
Add a `timeout` parameter to get/post/put/delete methods

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -112,3 +112,7 @@ Tips
 To run a subset of tests::
 
     $ python -m unittest tests.test_iland
+
+To run an individual test::
+
+    $ python -m unittest tests.test_iland.TestIland.<test_method_name>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+1.0.2 (2019-02-15)
+------------------
+
+* Added support for `timeout` parameter to `get`/`post`/`put`/`delete` methods
+
 1.0.1 (2018-11-15)
 ------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,4 +37,10 @@ and set the ``_proxies`` attribute on the api object::
     >>> api._proxies = {'https': 'https://10.10.1.10:3128'}
     >>> user = api.get('/user/' + USERNAME)
 
+The ``get``, ``post``, ``put``, and ``delete`` methods can accept an optional
+``_timeout`` parameter that is passed to ``requests``::
+
+    >>> user = api.get('/user/' + USERNAME, timeout=5.0)
+
 .. _proxies: http://docs.python-requests.org/en/master/user/advanced/#proxies
+.. _timeout: http://docs.python-requests.org/en/master/user/quickstart/#timeouts

--- a/iland/api.py
+++ b/iland/api.py
@@ -112,7 +112,8 @@ class Api(object):
         token_string = self._get_access_token()['access_token']
         return token_string
 
-    def _do_request(self, rpath, verb='GET', form_data=None, headers=None):
+    def _do_request(self, rpath, verb='GET', form_data=None, headers=None,
+                    timeout=None):
         self._refresh_token()
         data = None
         if form_data is not None:
@@ -141,7 +142,8 @@ class Api(object):
 
         request_params = {
             'headers': merged_headers,
-            'verify':  self._verify_ssl
+            'verify':  self._verify_ssl,
+            'timeout': timeout
         }
 
         if verb in ('PUT', 'POST'):
@@ -169,7 +171,7 @@ class Api(object):
             raise ApiException(json_obj)
         return json_obj
 
-    def get(self, rpath, headers=None):
+    def get(self, rpath, headers=None, timeout=None):
         """ Perform a GET request against the iland cloud API given its
         resource path.
 
@@ -182,9 +184,9 @@ class Api(object):
         :raises: UnauthorizedException: credentials / grants invalids
         :return: a JSON Object or a list of JSON Objects.
         """
-        return self._do_request(rpath, headers=headers)
+        return self._do_request(rpath, headers=headers, timeout=timeout)
 
-    def put(self, rpath, form_data=None, headers=None):
+    def put(self, rpath, form_data=None, headers=None, timeout=None):
         """ Perform a PUT request against the iland cloud API given its
         resource path.
 
@@ -201,7 +203,7 @@ class Api(object):
         return self._do_request(rpath, verb='PUT', form_data=form_data,
                                 headers=headers)
 
-    def post(self, rpath, form_data=None, headers=None):
+    def post(self, rpath, form_data=None, headers=None, timeout=None):
         """ Perform a POST request against the iland cloud API given its
         resource path.
 
@@ -218,7 +220,7 @@ class Api(object):
         return self._do_request(rpath, verb='POST', form_data=form_data,
                                 headers=headers)
 
-    def delete(self, rpath, headers=None):
+    def delete(self, rpath, headers=None, timeout=None):
         """ Perform a DELETE request against the iland cloud API given its
         resource path.
 

--- a/tests/test_iland.py
+++ b/tests/test_iland.py
@@ -330,3 +330,15 @@ class TestIland(unittest.TestCase):
             # Set Accept to text/csv but it's ignored by api, so we get json
             req = self.api.get(rpath, headers={'Accept': 'text/csv'})
             self.assertEquals(user_data, req)
+
+    def test_get_with_timeout(self):
+        with requests_mock.mock() as m:
+            m.post(iland.ACCESS_URL,
+                   text=json.dumps(VALID_TOKEN_PAYLOAD),
+                   status_code=200)
+            rpath = '/user/jchirac'
+            user_data = {'username': 'jchirac'}
+            m.get(BASE_URL + rpath, text=json.dumps(user_data),
+                  status_code=200)
+            req = self.api.get(rpath, timeout=5.0)
+            self.assertEquals(user_data, req)


### PR DESCRIPTION
This change adds the ability to pass a `requests` style `timeout` parameter to the `iland.Api` `get`/`post`/`put`/`delete` methods.